### PR TITLE
Make the old-style samples tests expect errors on `test:cannot-convert` lines.

### DIFF
--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -149,7 +149,8 @@ abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
     if (missing.getMessage().contains("jspecify_but_expect_error")
         || missing.getMessage().contains("jspecify_but_expect_warning")
         || missing.getMessage().contains("jspecify_nullness_not_enough_information")
-        || missing.getMessage().contains("jspecify_nullness_mismatch")) {
+        || missing.getMessage().contains("jspecify_nullness_mismatch")
+        || missing.getMessage().contains("test:cannot-convert")) {
       switch (unexpected.messageKey) {
         case "argument":
         case "assignment":


### PR DESCRIPTION
This is necessary before we can merge `main` into
`samples-google-prototype`.

This PR depends on https://github.com/jspecify/checker-framework/pull/33
