### PR TITLE
Update links for repo rename.

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -1796,7 +1796,7 @@ final class NullSpecAnnotatedTypeFactory
      *
      * Additionally, when I was letting CF write computed annotations into bytecode, I ran into an
      * type.invalid.conflicting.annos error, which I have described more in
-     * https://github.com/jspecify/nullness-checker-for-checker-framework/commit/d16a0231487e239bc94145177de464b5f77c8b19
+     * https://github.com/jspecify/jspecify-reference-checker/commit/d16a0231487e239bc94145177de464b5f77c8b19
      */
   }
 

--- a/src/main/java/com/google/jspecify/nullness/NullSpecVisitor.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecVisitor.java
@@ -424,7 +424,7 @@ final class NullSpecVisitor extends BaseTypeVisitor<NullSpecAnnotatedTypeFactory
    * visitTypeParameter and visitAnnotatedType because we want to operate on source trees, rather
    * than on derived types. For more details, see the bullet points below, plus the additional notes
    * in the commit message of
-   * https://github.com/jspecify/nullness-checker-for-checker-framework/commit/611717437c3c8b967de6d21615223975dd97b60a
+   * https://github.com/jspecify/jspecify-reference-checker/commit/611717437c3c8b967de6d21615223975dd97b60a
    *
    * - If we instead want to look for annotations on a type parameter or wildcard based on the
    * derived types, we need to ask CF questions like "What is the lower/upper bound?" since that is


### PR DESCRIPTION
The old links would redirect automatically, but I'm trying to look at
all references, and it's easier if I don't have to remember to ignore
these ones.
