### PR TITLE
Update the jar name for the new repo name.

### DIFF
--- a/demo
+++ b/demo
@@ -4,7 +4,7 @@
 # To integrate the checker into a more complex build, reading the below should give you what you need to know.
 
 dir=$(dirname $0)
-ourclasspath="$dir/../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar:$dir/build/libs/nullness-checker-for-checker-framework.jar"
+ourclasspath="$dir/../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar:$dir/build/libs/jspecify-reference-checker.jar"
 
 export CLASSPATH="$ourclasspath:$CLASSPATH"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
+// Project name is read-only in build scripts, and defaults to directory name.
+rootProject.name = "jspecify-reference-checker"
+
 def initializeProject() {
     exec {
         executable './initialize-project'


### PR DESCRIPTION
This includes:

- updating the jar name that the demo script looks for, since that name
  is automatically derived from the directory you clone the checker
  into, and users are likely to clone into a directory named after the
  repo
- changing the Gradle config to not automatically derive the jar name
  from the directory you clone the checker into, because _seriously_....
  So now the name will be the same no matter what you name your
  directory, including if you always name the directory after the repo.
  But note that this is a change from the
  nullness-checker-for-checker-framework name that people might be using
  for their existing clones. Previously:
  https://github.com/jspecify/jspecify/pull/150
