### PR TITLE
Build `jspecify` in addition to `checker-framework`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
 // Assemble checker-framework when assembling the reference checker.
 assemble.dependsOn(gradle.includedBuild("checker-framework").task(":assemble"))
+assemble.dependsOn(gradle.includedBuild("jspecify").task(":assemble"))
 
 tasks.withType(JavaCompile).all {
     options.compilerArgs.add("-Xlint:all")


### PR DESCRIPTION
Fixes https://github.com/jspecify/jspecify-reference-checker/issues/93

Compare https://github.com/jspecify/jspecify-reference-checker/pull/85
