### PR TITLE
Emit report lines for expected facts in the same order in which they appear in the input file.

### DIFF
--- a/src/test/java/tests/conformance/AbstractConformanceTest.java
+++ b/src/test/java/tests/conformance/AbstractConformanceTest.java
@@ -135,7 +135,8 @@ public abstract class AbstractConformanceTest {
         } else {
           facts.forEach(
               (factLineNumber, expectedFact) ->
-                  expectedFacts.add(new ExpectedFact(file, lineNumber, fact, factLineNumber)));
+                  expectedFacts.add(
+                      new ExpectedFact(file, lineNumber, expectedFact, factLineNumber)));
           facts.clear();
         }
       }

--- a/src/test/java/tests/conformance/ConformanceTestReport.java
+++ b/src/test/java/tests/conformance/ConformanceTestReport.java
@@ -49,7 +49,6 @@ public final class ConformanceTestReport {
         index(reportedFacts, ReportedFact::getLineNumber);
     ImmutableListMultimap<ExpectedFactAssertion, ReportedFact> matchingFacts =
         expectedFacts.stream()
-            .sorted(comparingLong(ExpectedFactAssertion::getLineNumber))
             .collect(
                 flatteningToImmutableListMultimap(
                     f -> f,
@@ -111,9 +110,12 @@ public final class ConformanceTestReport {
           ImmutableSortedSet.copyOf(
               union(expectedFactsInFile.keySet(), reportedFactsInFile.keySet()))) {
         // Report all expected facts on this line and whether they're reported or not.
-        for (ExpectedFactAssertion expectedFact : expectedFactsInFile.get(lineNumber)) {
-          writeFact(report, expectedFact, matchesReportedFact(expectedFact) ? "PASS" : "FAIL");
-        }
+        expectedFactsInFile.get(lineNumber).stream()
+            .sorted(comparingLong(ExpectedFactAssertion::getFactLineNumber))
+            .forEach(
+                expectedFact ->
+                    writeFact(
+                        report, expectedFact, matchesReportedFact(expectedFact) ? "PASS" : "FAIL"));
         if (details) {
           // Report all unexpected facts on this line and whether they must be expected or not.
           for (ReportedFact reportedFact : reportedFactsInFile.get(lineNumber)) {


### PR DESCRIPTION
Fixes #103.