### PR TITLE
Run conformance tests first, and jspecifySamplesTest second.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,13 @@ jobs:
           arguments: build
         env:
           SHALLOW: 1
-      - name: Run Samples Tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jspecifySamplesTest
-      - name: Check out jspecify/main
-        run: git -C ../jspecify checkout main
       - name: Run Conformance Tests
         uses: gradle/gradle-build-action@v2
         with:
           arguments: conformanceTest conformanceTestOnSamples
+      - name: Check out jspecify/samples-google-prototype
+        run: git -C ../jspecify checkout samples-google-prototype
+      - name: Run Samples Tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jspecifySamplesTest

--- a/initialize-project
+++ b/initialize-project
@@ -63,10 +63,9 @@ git_clone() {
   run "${git[@]}" "https://github.com/jspecify/${repo}.git" "../${repo}"
 }
 
-# We test using some modified samples in a different branch of the jspecify
-# repo, so we check out that branch. However, we fetch all branches even when
-# SHALLOW is set so we can run conformance tests.
-git_clone jspecify --no-single-branch --branch samples-google-prototype
+# Fetch all branches even when $SHALLOW is set so we can check out
+# samples-google-prototype to run samples tests.
+git_clone jspecify --no-single-branch
 
 git_clone jdk --depth 1 --single-branch
 


### PR DESCRIPTION
Check out `jspecify/main` and run conformance tests first. Then checkout `samples-google-prototype` and run `jspecifySamplesTest` second.

This will allow us to make the `check` lifecycle task depend on the conformance test tasks, which will mean that `build` will run them too.