### PR TITLE
Always check samples in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
         env:
           SHALLOW: 1
       - name: Check out jspecify/samples-google-prototype
-        run: git -C ../jspecify checkout samples-google-prototype
         if: always()
+        run: git -C ../jspecify checkout samples-google-prototype
       - name: Run Samples Tests
+        if: always()
         uses: gradle/gradle-build-action@v2
         with:
           arguments: jspecifySamplesTest
-        if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
           SHALLOW: 1
       - name: Check out jspecify/samples-google-prototype
         run: git -C ../jspecify checkout samples-google-prototype
+        if: always()
       - name: Run Samples Tests
         uses: gradle/gradle-build-action@v2
         with:
           arguments: jspecifySamplesTest
+        if: always()


### PR DESCRIPTION
As suggested [here](https://github.com/jspecify/jspecify-reference-checker/pull/118/files#r1423234545) it will be good to see sample results, even if conformance tests might fail.