### PR TITLE
Log failure to parse a type instead of throwing.

### DIFF
--- a/src/test/java/tests/ConformanceTest.java
+++ b/src/test/java/tests/ConformanceTest.java
@@ -14,7 +14,6 @@
 
 package tests;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
@@ -35,6 +34,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -84,6 +84,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public final class ConformanceTest {
+  private static final Logger logger = Logger.getLogger(ConformanceTest.class.getCanonicalName());
 
   private static final ImmutableList<String> OPTIONS =
       ImmutableList.of(
@@ -242,7 +243,10 @@ public final class ConformanceTest {
      */
     private static String fixType(String type) {
       Matcher matcher = TYPE.matcher(type);
-      checkArgument(matcher.matches(), "did not match for \"%s\"", type);
+      if (!matcher.matches()) {
+        logger.warning(String.format("type \"%s\" did not match /%s/", type, TYPE.pattern()));
+        return type;
+      }
       String args = matcher.group("args");
       String suffix = matcher.group("suffix");
       if (args == null && suffix != null) {

--- a/tests/ConformanceTest-report.txt
+++ b/tests/ConformanceTest-report.txt
@@ -1,11 +1,12 @@
-# 12 pass; 6 fail; 18 total; 66.7% score
-PASS: Basic.java:26 test:expression-type:Object?:nullable
-PASS: Basic.java:26 test:sink-type:Object!:return
-PASS: Basic.java:26 test:cannot-convert:Object? to Object!
-PASS: Basic.java:32 test:expression-type:Object!:nonNull
-PASS: Basic.java:32 test:sink-type:Object?:return
-PASS: Basic.java:39 test:sink-type:Object?:nullableObject
-PASS: Basic.java:41 test:sink-type:String!:testSinkType#nonNullString
+# 12 pass; 7 fail; 19 total; 63.2% score
+PASS: Basic.java:28 test:expression-type:Object?:nullable
+PASS: Basic.java:28 test:sink-type:Object!:return
+PASS: Basic.java:28 test:cannot-convert:Object? to Object!
+PASS: Basic.java:34 test:expression-type:Object!:nonNull
+PASS: Basic.java:34 test:sink-type:Object?:return
+PASS: Basic.java:41 test:sink-type:Object?:nullableObject
+PASS: Basic.java:43 test:sink-type:String!:testSinkType#nonNullString
+FAIL: Basic.java:49 test:expression-type:List!<capture of ? extends String?>:nullableStrings
 PASS: Basic.java: no unexpected facts
 PASS: Irrelevant.java:28 test:irrelevant-annotation:Nullable
 PASS: Irrelevant.java:34 test:irrelevant-annotation:Nullable


### PR DESCRIPTION
Fixes #120.

Depends on https://github.com/jspecify/jspecify/pull/430.