### PR TITLE
Use the samples files from the conformance tests zip.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,11 +113,7 @@ tasks.register('jspecifySamplesTest', Test) {
     include '**/NullSpecTest$Lenient.class'
     include '**/NullSpecTest$Strict.class'
 
-    if (findProject(':conformance-tests') != null) {
-        inputs.files(unzipConformanceTestSuite)
-    } else {
-        inputs.dir('../jspecify/samples')
-    }
+    inputs.files(unzipConformanceTestSuite)
 }
 
 tasks.register('unzipConformanceTestSuite', Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ tasks.register('jspecifySamplesTest', Test) {
     include '**/NullSpecTest$Lenient.class'
     include '**/NullSpecTest$Strict.class'
 
-    inputs.files("${jspecify.projectDir}/samples")
+    inputs.files(unzipConformanceTestSuite)
 }
 
 tasks.register('unzipConformanceTestSuite', Copy) {
@@ -140,11 +140,11 @@ tasks.register('conformanceTests', Test) {
     }
 
     // Conformance tests run on the samples directory
-    inputs.dir("${jspecify.projectDir}/samples")
+    inputs.dir("${unzipConformanceTestSuite.destinationDir}/samples")
     inputs.files("tests/ConformanceTestOnSamples-report.txt")
     doFirst {
         systemProperties([
-            "JSpecifyConformanceTest.samples.inputs": "${jspecify.projectDir}/samples",
+            "JSpecifyConformanceTest.samples.inputs": "${unzipConformanceTestSuite.destinationDir}/samples",
             "JSpecifyConformanceTest.samples.report": "tests/ConformanceTestOnSamples-report.txt"
         ])
     }

--- a/build.gradle
+++ b/build.gradle
@@ -113,12 +113,16 @@ tasks.register('jspecifySamplesTest', Test) {
     include '**/NullSpecTest$Lenient.class'
     include '**/NullSpecTest$Strict.class'
 
-    inputs.files(unzipConformanceTestSuite)
+    if (findProject(':conformance-tests') != null) {
+        inputs.files(unzipConformanceTestSuite)
+    } else {
+        inputs.dir('../jspecify/samples')
+    }
 }
 
 tasks.register('unzipConformanceTestSuite', Copy) {
     // TODO: Don't explicitly depend on an included build's task.
-    dependsOn jspecify.task(':conformance-tests:build')
+    dependsOn jspecify.tasks.findByPath(':conformance-tests:build')
     dependsOn configurations.conformanceTestSuite
     from zipTree(configurations.conformanceTestSuite.singleFile)
     into layout.buildDirectory.dir("conformanceTests")

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ tasks.register('jspecifySamplesTest', Test) {
 
 tasks.register('unzipConformanceTestSuite', Copy) {
     // TODO: Don't explicitly depend on an included build's task.
-    dependsOn jspecify.tasks.findByPath(':conformance-tests:build')
+    dependsOn jspecify.task(':conformance-tests:build')
     dependsOn configurations.conformanceTestSuite
     from zipTree(configurations.conformanceTestSuite.singleFile)
     into layout.buildDirectory.dir("conformanceTests")

--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -40,7 +40,7 @@ abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
   private static String[] getSamplesDirs() {
     return new String[] {
       SAMPLES_DIRECTORIES.stream()
-          .filter(d -> isDirectory(Paths.get(d)))
+          .filter(d -> isDirectory(Paths.get("tests", d)))
           .findFirst()
           .orElseThrow(
               () ->

--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -14,12 +14,9 @@
 
 package tests;
 
-import static java.nio.file.Files.isDirectory;
-
 import com.google.common.collect.ImmutableList;
 import com.google.jspecify.nullness.NullSpecChecker;
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -32,22 +29,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 /** Tests for the {@link NullSpecChecker} that look at expected diagnostics in source files. */
 abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
-  // TODO: Remove the old location of the samples once the ZIP file has them even on the
-  // samples-google-prototype branch.
-  private static final ImmutableList<String> SAMPLES_DIRECTORIES =
-      ImmutableList.of("../build/conformanceTests/samples", "../../jspecify/samples");
-
-  private static String[] getSamplesDirs() {
-    return new String[] {
-      SAMPLES_DIRECTORIES.stream()
-          .filter(d -> isDirectory(Paths.get("tests", d)))
-          .findFirst()
-          .orElseThrow(
-              () ->
-                  new IllegalStateException("Cannot find samples in any of " + SAMPLES_DIRECTORIES))
-    };
-  }
-
   /** A minimal smoke test that looks at one simple file. */
   public static class Minimal extends NullSpecTest {
     public Minimal(List<File> testFiles) {
@@ -82,6 +63,10 @@ abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
     public static String[] getTestDirs() {
       return getSamplesDirs();
     }
+  }
+
+  private static String[] getSamplesDirs() {
+    return new String[] {"../build/conformanceTests/samples"};
   }
 
   private final boolean strict;

--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -14,9 +14,12 @@
 
 package tests;
 
+import static java.nio.file.Files.isDirectory;
+
 import com.google.common.collect.ImmutableList;
 import com.google.jspecify.nullness.NullSpecChecker;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -29,6 +32,22 @@ import org.junit.runners.Parameterized.Parameters;
 
 /** Tests for the {@link NullSpecChecker} that look at expected diagnostics in source files. */
 abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
+  // TODO: Remove the old location of the samples once the ZIP file has them even on the
+  // samples-google-prototype branch.
+  private static final ImmutableList<String> SAMPLES_DIRECTORIES =
+      ImmutableList.of("../build/conformanceTests/samples", "../../jspecify/samples");
+
+  private static String[] getSamplesDirs() {
+    return new String[] {
+      SAMPLES_DIRECTORIES.stream()
+          .filter(d -> isDirectory(Paths.get(d)))
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new IllegalStateException("Cannot find samples in any of " + SAMPLES_DIRECTORIES))
+    };
+  }
+
   /** A minimal smoke test that looks at one simple file. */
   public static class Minimal extends NullSpecTest {
     public Minimal(List<File> testFiles) {
@@ -49,7 +68,7 @@ abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
 
     @Parameters
     public static String[] getTestDirs() {
-      return new String[] {"../../jspecify/samples"};
+      return getSamplesDirs();
     }
   }
 
@@ -61,7 +80,7 @@ abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
 
     @Parameters
     public static String[] getTestDirs() {
-      return new String[] {"../../jspecify/samples"};
+      return getSamplesDirs();
     }
   }
 


### PR DESCRIPTION
Depends on https://github.com/jspecify/jspecify/pull/438.

Helps to decouple this build from [JSpecify](https://github.com/jspecify/jspecify).