### PR TITLE
Don't include the JDK sibling project in this build.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,10 +16,6 @@ includeBuild("../jspecify") {
     initializeProject()
 }
 
-includeBuild("../jdk") {
-    initializeProject()
-}
-
 includeBuild("../checker-framework") {
     initializeProject()
 }


### PR DESCRIPTION
 We don't depend on any of its tasks directly. It will still be cloned during project initialization.