### PR TITLE
Use published conformance tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,15 @@ jobs:
       run:
         working-directory: jspecify-reference-checker
     steps:
-      - name: Check out the code
+      - name: Check out jspecify-reference checker
         uses: actions/checkout@v4
         with:
           path: jspecify-reference-checker
+      - name: Check out jspecify
+        uses: actions/checkout@v4
+        with:
+          repository: jspecify/jspecify
+          path: jspecify
       - name: Set up Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,9 @@ jobs:
           SHALLOW: 1
       - name: Check out jspecify/samples-google-prototype
         if: always()
-        run: git checkout samples-google-prototype
+        run: |
+          git fetch --depth=1 samples-google-prototype
+          git checkout samples-google-prototype
         working-directory: jspecify
       - name: Run Samples Tests
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check out jspecify/samples-google-prototype
         if: always()
         run: |
-          git fetch --depth=1 samples-google-prototype
+          git fetch --depth=1 origin samples-google-prototype
           git checkout samples-google-prototype
         working-directory: jspecify
       - name: Run Samples Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build and Test
-        run: ./gradlew build conformanceTests demoTest
+        run: ./gradlew build conformanceTests demoTest --include-build ../jspecify
         env:
           SHALLOW: 1
       - name: Check out jspecify/samples-google-prototype
@@ -38,4 +38,4 @@ jobs:
         working-directory: jspecify
       - name: Run Samples Tests
         if: always()
-        run: ./gradlew jspecifySamplesTest
+        run: ./gradlew jspecifySamplesTest --include-build ../jspecify

--- a/README.md
+++ b/README.md
@@ -58,20 +58,26 @@ git clone https://github.com/jspecify/jspecify-reference-checker
 cd jspecify-reference-checker
 ```
 
-Now build it, which will retrieve a lot of other code too, and will take 10-15 minutes:
+Now build it, which will retrieve a lot of other code too, and will take 10-15
+minutes:
 
 ```sh
 ./gradlew assemble
 ```
 
-Now try the sample file:
+### Demonstration
+
+Run the checker on the sample file:
 
 ```sh
 cd $root_dir/jspecify-reference-checker
 ./demo SimpleSample.java
 ```
 
-After ~10 seconds delay, you should see
+(If you haven't [built the reference checker](#building) yet, this will build it
+the first time you run it.)
+
+After that, you should see:
 
 ```
 SimpleSample.java:7: error: [nullness] incompatible types in return.

--- a/build.gradle
+++ b/build.gradle
@@ -18,21 +18,22 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    checkerFramework = gradle.includedBuild("checker-framework")
+    jspecify = gradle.includedBuilds.find { it.name == 'jspecify' }
+}
+
 configurations {
     errorproneJavac
     conformanceTestSuite {
         // When including a local JSpecify build, depend on the local test suite.
         // See https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing.
-        if (gradle.includedBuilds.find { it.name == 'jspecify' } != null) {
+        if (jspecify != null) {
             attributes {
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, 'conformance-tests'))
             }
         }
     }
-}
-
-ext {
-    checkerFramework = gradle.includedBuild("checker-framework")
 }
 
 java {
@@ -61,6 +62,9 @@ dependencies {
 
 // Assemble checker-framework when assembling the reference checker.
 assemble.dependsOn(checkerFramework.task(":assemble"))
+if (jspecify != null) {
+    assemble.dependsOn(jspecify.task('assemble'))
+}
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs.add("-Xlint:all")

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,21 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
+    maven {
+        // Nexus snapshot repository
+        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    }
     mavenCentral()
 }
 
 configurations {
     errorproneJavac
-    conformanceTestSuite
+    conformanceTestSuite {
+        // Only download from Maven; don't try to use the included build.
+        // Composite build dependencies don't work for nonstandard artifacts like ZIP files.
+        resolutionStrategy.useGlobalDependencySubstitutionRules = false
+    }
 }
 
 ext {
@@ -41,8 +50,7 @@ dependencies {
     testImplementation libs.jspecify.conformanceTestFramework
     testRuntimeOnly libs.jsr305 // jsr305 annotations are in some of the samples
 
-    // TODO: Depend on a group:artifact:version rather than a file.
-    conformanceTestSuite files("${jspecify.projectDir}/conformance-tests/build/distributions/conformance-tests-0.0.0-SNAPSHOT.zip")
+    conformanceTestSuite libs.jspecify.conformanceTests
 
     errorproneJavac libs.errorProne.javac
     errorprone libs.errorProne.core

--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ tasks.register('demoTest', Exec)  {
     ignoreExitValue = true
     errorOutput = new ByteArrayOutputStream()
     doLast {
-        if (!errorOutput.toString().startsWith("SimpleSample.java:7: error:")) {
+        if (!errorOutput.toString().contains("SimpleSample.java:7: error:")) {
             throw new AssertionError("`./demo SimpleSample.java` did not run correctly. Error output:\n$errorOutput")
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ configurations {
 
 ext {
     checkerFramework = gradle.includedBuild("checker-framework")
-    jspecify = gradle.includedBuild("jspecify")
 }
 
 java {
@@ -58,7 +57,6 @@ dependencies {
 
 // Assemble checker-framework when assembling the reference checker.
 assemble.dependsOn(checkerFramework.task(":assemble"))
-assemble.dependsOn(jspecify.task(":assemble"))
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs.add("-Xlint:all")
@@ -125,8 +123,6 @@ tasks.register('jspecifySamplesTest', Test) {
 }
 
 tasks.register('unzipConformanceTestSuite', Copy) {
-    // TODO: Don't explicitly depend on an included build's task.
-    dependsOn jspecify.task(':conformance-tests:build')
     dependsOn configurations.conformanceTestSuite
     from zipTree(configurations.conformanceTestSuite.singleFile)
     into layout.buildDirectory.dir("conformanceTests")
@@ -148,11 +144,11 @@ tasks.register('conformanceTests', Test) {
     }
 
     // Conformance tests run on the samples directory
-    inputs.dir("${jspecify.projectDir}/samples")
+    inputs.dir("../jspecify/samples")
     inputs.files("tests/ConformanceTestOnSamples-report.txt")
     doFirst {
         systemProperties([
-            "JSpecifyConformanceTest.samples.inputs": "${jspecify.projectDir}/samples",
+            "JSpecifyConformanceTest.samples.inputs": "../jspecify//samples",
             "JSpecifyConformanceTest.samples.report": "tests/ConformanceTestOnSamples-report.txt"
         ])
     }

--- a/build.gradle
+++ b/build.gradle
@@ -186,8 +186,8 @@ tasks.register('demoTest', Exec)  {
  */
 
 def cfQualJar =
-        checkerFramework.projectDir.toPath()
-        .resolve("checker-qual/build/libs/checker-qual-${libs.versions.checkerFramework.get()}.jar")
+        gradle.includedBuild('checker-framework').projectDir.toPath()
+                .resolve("checker-qual/build/libs/checker-qual-${libs.versions.checkerFramework.get()}.jar")
 
 if (!cfQualJar.toFile().exists()) {
     mkdir(cfQualJar.parent)

--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ tasks.register('demoTest', Exec)  {
 
 def cfQualJar =
         gradle.includedBuild('checker-framework').projectDir.toPath()
-                .resolve("checker-qual/build/libs/checker-qual-${libs.versions.checkerFramework.get()}.jar")
+        .resolve("checker-qual/build/libs/checker-qual-${libs.versions.checkerFramework.get()}.jar")
 
 if (!cfQualJar.toFile().exists()) {
     mkdir(cfQualJar.parent)

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,10 @@ tasks.register('jspecifySamplesTest', Test) {
 }
 
 tasks.register('unzipConformanceTestSuite', Copy) {
+    IncludedBuild jspecify = gradle.includedBuilds.find {it.name == 'jspecify' }
+    if (jspecify != null) {
+        dependsOn jspecify.task(':publishConformanceTestsPublicationToMavenLocal')
+    }
     dependsOn configurations.conformanceTestSuite
     from zipTree(configurations.conformanceTestSuite.singleFile)
     into layout.buildDirectory.dir("conformanceTests")

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ repositories {
 
 ext {
     checkerFramework = gradle.includedBuild("checker-framework")
+
+    // null if not included with `--include-build path/to/jspecify`
     jspecify = gradle.includedBuilds.find { it.name == 'jspecify' }
 }
 
@@ -62,6 +64,9 @@ dependencies {
 
 // Assemble checker-framework when assembling the reference checker.
 assemble.dependsOn(checkerFramework.task(":assemble"))
+
+// If built with `--include-build path/to/jspecify` then
+// assemble jspecify when assembling the reference checker.
 if (jspecify != null) {
     assemble.dependsOn(jspecify.task(':assemble'))
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 // Assemble checker-framework when assembling the reference checker.
 assemble.dependsOn(checkerFramework.task(":assemble"))
 if (jspecify != null) {
-    assemble.dependsOn(jspecify.task('assemble'))
+    assemble.dependsOn(jspecify.task(':assemble'))
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,6 @@ configurations {
     }
 }
 
-ext {
-    checkerFramework = gradle.includedBuild("checker-framework")
-}
-
 java {
     sourceCompatibility = 1.9
 }
@@ -54,9 +50,6 @@ dependencies {
     errorproneJavac libs.errorProne.javac
     errorprone libs.errorProne.core
 }
-
-// Assemble checker-framework when assembling the reference checker.
-assemble.dependsOn(checkerFramework.task(":assemble"))
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs.add("-Xlint:all")
@@ -160,31 +153,6 @@ tasks.named('check').configure {
 
 clean.doFirst {
     delete "${rootDir}/tests/build/"
-}
-
-/*
- Spotless validates its formatters' dependencies eagerly, on project configuration.
- google-java-format depends on checker-qual, which is built by a subproject.
- On a clean build, the checker-qual JAR file doesn't exist yet, so Spotless throws an error.
- The file doesn't have to be correct; it just has to be a JAR file.
- So here, before the spotless block,  we create a meaningless JAR file at that location if it doesn't already exist.
- See https://github.com/jspecify/jspecify-reference-checker/issues/81
- */
-
-def cfQualJar =
-        checkerFramework.projectDir.toPath()
-        .resolve("checker-qual/build/libs/checker-qual-${libs.versions.checkerFramework.get()}.jar")
-
-if (!cfQualJar.toFile().exists()) {
-    mkdir(cfQualJar.parent)
-    exec {
-        executable 'jar'
-        args = [
-            'cf',
-            cfQualJar,
-            buildFile.path // Use this build script file!
-        ]
-    }
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,6 @@ tasks.register('conformanceTests', Test) {
     }
 
     // Conformance tests run on the samples directory
-    inputs.dir("${unzipConformanceTestSuite.destinationDir}/samples")
     inputs.files("tests/ConformanceTestOnSamples-report.txt")
     doFirst {
         systemProperties([

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ test {
 tasks.register('jspecifySamplesTest', Test) {
     description = 'Run the checker against the JSpecify samples.'
     group = 'verification'
+    shouldRunAfter test
     include '**/NullSpecTest$Lenient.class'
     include '**/NullSpecTest$Strict.class'
 
@@ -124,6 +125,7 @@ tasks.register('unzipConformanceTestSuite', Copy) {
 tasks.register('conformanceTests', Test) {
     group = 'verification'
     include '**/ConformanceTest.class'
+    shouldRunAfter test
 
     // Conformance tests
     inputs.files(unzipConformanceTestSuite)

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,13 @@ repositories {
 configurations {
     errorproneJavac
     conformanceTestSuite {
-        // Only download from Maven; don't try to use the included build.
-        // Composite build dependencies don't work for nonstandard artifacts like ZIP files.
-        resolutionStrategy.useGlobalDependencySubstitutionRules = false
+        // When including a local JSpecify build, depend on the local test suite.
+        // See https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing.
+        if (gradle.includedBuilds.find { it.name == 'jspecify' } != null) {
+            attributes {
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, 'conformance-tests'))
+            }
+        }
     }
 }
 
@@ -117,10 +121,6 @@ tasks.register('jspecifySamplesTest', Test) {
 }
 
 tasks.register('unzipConformanceTestSuite', Copy) {
-    IncludedBuild jspecify = gradle.includedBuilds.find {it.name == 'jspecify' }
-    if (jspecify != null) {
-        dependsOn jspecify.task(':publishConformanceTestsPublicationToMavenLocal')
-    }
     dependsOn configurations.conformanceTestSuite
     from zipTree(configurations.conformanceTestSuite.singleFile)
     into layout.buildDirectory.dir("conformanceTests")

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ configurations {
     }
 }
 
+ext {
+    checkerFramework = gradle.includedBuild("checker-framework")
+}
+
 java {
     sourceCompatibility = 1.9
 }
@@ -54,6 +58,9 @@ dependencies {
     errorproneJavac libs.errorProne.javac
     errorprone libs.errorProne.core
 }
+
+// Assemble checker-framework when assembling the reference checker.
+assemble.dependsOn(checkerFramework.task(":assemble"))
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs.add("-Xlint:all")
@@ -186,7 +193,7 @@ tasks.register('demoTest', Exec)  {
  */
 
 def cfQualJar =
-        gradle.includedBuild('checker-framework').projectDir.toPath()
+        checkerFramework.projectDir.toPath()
         .resolve("checker-qual/build/libs/checker-qual-${libs.versions.checkerFramework.get()}.jar")
 
 if (!cfQualJar.toFile().exists()) {

--- a/demo
+++ b/demo
@@ -1,6 +1,6 @@
 #!/bin/sh
 # A quick and easy way to run the reference checker on some standalone code.
-# If you set the CLASSPATH environment variable it will ues it, adding its own entries to that list.
+# If you set the CLASSPATH environment variable it will use it, adding its own entries to that list.
 # To integrate the checker into a more complex build, reading the below should give you what you need to know.
 
 dir=$(dirname $0)

--- a/demo
+++ b/demo
@@ -15,13 +15,13 @@ if [ ! -e "${jspecify}" ]; then
       -DoutputDirectory="$(dirname "${jspecify}")"
   fi
 fi
-jspecifyReferenceChecker="${dir}/build/libs/jspecify-reference-checker.jar"
-if [ ! -e "${jspecifyReferenceChecker}" ]; then
+jspecify_reference_checker="${dir}/build/libs/jspecify-reference-checker.jar"
+if [ ! -e "${jspecify_reference_checker}" ]; then
   echo "Assembling jspecify-reference-checker"
   ./gradlew assemble
 fi
 
-ourclasspath="${jspecify}:${jspecifyReferenceChecker}"
+ourclasspath="${jspecify}:${jspecify_reference_checker}"
 
 export CLASSPATH="${ourclasspath}:$CLASSPATH"
 

--- a/demo
+++ b/demo
@@ -8,12 +8,20 @@ jspecify="${dir}/../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"
 if [ ! -e "${jspecify}" ]; then
   version=0.3.0
   jspecify="${dir}/build/jspecify-${version}.jar"
-  echo "Downloading $(basename "${jspecify}") from Maven central"
-  mvn -q org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy \
-    -Dartifact="org.jspecify:jspecify:${version}" \
-    -DoutputDirectory="$(dirname "${jspecify}")"
+  if [ ! -e "${jspecify}" ]; then
+    echo "Downloading $(basename "${jspecify}") from Maven central"
+    mvn -q org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy \
+      -Dartifact="org.jspecify:jspecify:${version}" \
+      -DoutputDirectory="$(dirname "${jspecify}")"
+  fi
 fi
-ourclasspath="${jspecify}:${dir}/build/libs/jspecify-reference-checker.jar"
+jspecifyReferenceChecker="${dir}/build/libs/jspecify-reference-checker.jar"
+if [ ! -e "${jspecifyReferenceChecker}" ]; then
+  echo "Assembling jspecify-reference-checker"
+  ./gradlew assemble
+fi
+
+ourclasspath="${jspecify}:${jspecifyReferenceChecker}"
 
 export CLASSPATH="${ourclasspath}:$CLASSPATH"
 

--- a/demo
+++ b/demo
@@ -6,16 +6,19 @@
 dir=$(dirname $0)
 jspecify="${dir}/../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"
 if [ ! -e "${jspecify}" ]; then
-  echo "Downloading JSpecify from Maven Central."
-  jspecify="${dir}/build/jspecify.jar"
-  curl -s 'https://repo.maven.apache.org/maven2/org/jspecify/jspecify/0.3.0/jspecify-0.3.0.jar' -o "${jspecify}"
+  version=0.3.0
+  jspecify="${dir}/build/jspecify-${version}.jar"
+  echo "Downloading $(basename "${jspecify}") from Maven central"
+  mvn -q org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy \
+    -Dartifact="org.jspecify:jspecify:${version}" \
+    -DoutputDirectory="$(dirname "${jspecify}")"
 fi
 ourclasspath="${jspecify}:${dir}/build/libs/jspecify-reference-checker.jar"
 
-export CLASSPATH="$ourclasspath:$CLASSPATH"
+export CLASSPATH="${ourclasspath}:$CLASSPATH"
 
 $dir/../checker-framework/checker/bin/javac \
-  -processorpath "$ourclasspath" \
+  -processorpath "${ourclasspath}" \
   -processor com.google.jspecify.nullness.NullSpecChecker \
   -AcheckImpl \
   -AassumePure \

--- a/demo
+++ b/demo
@@ -4,7 +4,13 @@
 # To integrate the checker into a more complex build, reading the below should give you what you need to know.
 
 dir=$(dirname $0)
-ourclasspath="$dir/../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar:$dir/build/libs/jspecify-reference-checker.jar"
+jspecify="${dir}/../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"
+if [ ! -e "${jspecify}" ]; then
+  echo "Downloading JSpecify from Maven Central."
+  jspecify="${dir}/build/jspecify.jar"
+  curl -s 'https://repo.maven.apache.org/maven2/org/jspecify/jspecify/0.3.0/jspecify-0.3.0.jar' -o "${jspecify}"
+fi
+ourclasspath="${jspecify}:${dir}/build/libs/jspecify-reference-checker.jar"
 
 export CLASSPATH="$ourclasspath:$CLASSPATH"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,46 @@
+# Development
+
+## Codevelopment with Checker Framework fork
+
+This project depends on
+an [unreleased fork of the Checker Framework][jspecify-checker-framework].
+(The [main-eisop branch] represents ongoing work to depend on a released version
+of the [EISOP] fork instead.)
+
+Because of that dependency, this build clones that unreleased fork into the
+sibling directory `../checker-framwork`.
+_That_ build then clones some other projects into other sibling directories. It
+expects `../jdk` to contain an annotated JDK, so our build
+clones [JSpecify's][jspecify-jdk] there.
+
+## Codevelopment with JSpecify
+
+This project depends on two artifacts built from the main [JSpecify repo]
+[jspecify-jspecify]:
+
+1. the annotations: `org.jspecify:jspecify`
+2. the conformance test suite: `org.jspecify.conformance:conformance-tests`
+
+For each of those dependencies, developers can depend on either a published
+version (fixed or snapshot) or a local build.
+
+In order to depend on a specific commit or uncommitted state of those artifacts,
+clone the repo (or your fork) somewhere, and pass
+`--include-build path/to/jspecify` to Gradle when building. The local clone will
+be used for both the annotations and the conformance test suite.
+
+By default the reference checker depends on version `0.3.0` of the annotations,
+and version `0.0.0-SNAPSHOT` of the conformance test suite.
+
+In order to depend on a different published version of either artifact, set
+Gradle properties on the command line.
+
+* `-Porg.jspecify:jspecify=0.2.0` would change the version of the annotations.
+* `-Porg.jspecify.conformance:conformance-tests=0.3.0` would change the version
+  of the conformance test suite.
+
+[EISOP]: https://github.com/eisop/checker-framework
+[jspecify-checker-framework]: https://github.com/jspecify/checker-framework
+[jspecify-jdk]: https://github.com/jspecify/jdk
+[jspecify-jspecify]: https://github.com/jspecify/jspecify
+[main-eisop branch]: https://github.com/jspecify/jspecify-reference-checker/tree/main-eisop

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.jspecify\:jspecify=0.3.0
+org.jspecify.conformance\:conformance-test-framework=0.0.0-SNAPSHOT
+org.jspecify.conformance\:conformance-tests=0.0.0-SNAPSHOT

--- a/initialize-project
+++ b/initialize-project
@@ -63,10 +63,6 @@ git_clone() {
   run "${git[@]}" "https://github.com/jspecify/${repo}.git" "../${repo}"
 }
 
-# Fetch all branches even when $SHALLOW is set so we can check out
-# samples-google-prototype to run samples tests.
-git_clone jspecify --no-single-branch
-
 git_clone jdk --depth 1 --single-branch
 
 git_clone checker-framework

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,11 +6,18 @@ include 'conformance-test-framework'
 // See https://docs.gradle.org/current/userguide/composite_builds.html#included_build_declaring_substitutions
 includeBuild(".")
 
-def initializeProject() {
-    exec {
-        executable './initialize-project'
+exec {
+    executable './initialize-project'
+}
+
+void includeBuildIfExists(String path) {
+    if (new File(path).isDirectory()) {
+        includeBuild(path)
     }
 }
+
+includeBuildIfExists('../jspecify')
+includeBuildIfExists('../checker-framework')
 
 dependencyResolutionManagement {
     versionCatalogs {

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,12 +25,19 @@ dependencyResolutionManagement {
             library("errorProne-core", "com.google.errorprone:error_prone_core:2.18.0")
             library("errorProne-javac", "com.google.errorprone:javac:9+181-r4173-1")
             library("guava", "com.google.guava:guava:31.1-jre")
-            library("jspecify", "org.jspecify:jspecify:0.3.0")
-            library("jspecify-conformanceTestFramework", "org.jspecify.conformance:conformance-test-framework:0.0.0-SNAPSHOT")
-            library("jspecify-conformanceTests", "org.jspecify.conformance:conformance-tests:0.0.0-SNAPSHOT")
+
+            // Related JSpecify project versions are specified in gradle.properties, and can be overridden on the Gradle command line.
+            library("jspecify", libraryVersion('org.jspecify:jspecify'))
+            library("jspecify-conformanceTestFramework", libraryVersion('org.jspecify.conformance:conformance-test-framework'))
+            library("jspecify-conformanceTests", libraryVersion('org.jspecify.conformance:conformance-tests'))
+
             library("jsr305", "com.google.code.findbugs:jsr305:3.0.2")
             library("junit", "junit:junit:4.12")
             library("truth", "com.google.truth:truth:1.1.3")
         }
     }
+}
+
+String libraryVersion(String groupArtifact) {
+    return "$groupArtifact:${settings[groupArtifact]}"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,10 +12,6 @@ def initializeProject() {
     }
 }
 
-includeBuild("../jspecify") {
-    initializeProject()
-}
-
 includeBuild("../checker-framework") {
     initializeProject()
 }
@@ -33,7 +29,7 @@ dependencyResolutionManagement {
             library("errorProne-core", "com.google.errorprone:error_prone_core:2.18.0")
             library("errorProne-javac", "com.google.errorprone:javac:9+181-r4173-1")
             library("guava", "com.google.guava:guava:31.1-jre")
-            library("jspecify", "org.jspecify:jspecify:0.0.0-SNAPSHOT")
+            library("jspecify", "org.jspecify:jspecify:0.3.0")
             library("jspecify-conformanceTestFramework", "org.jspecify.conformance:conformance-test-framework:0.0.0-SNAPSHOT")
             library("jspecify-conformanceTests", "org.jspecify.conformance:conformance-tests:0.1.0-SNAPSHOT")
             library("jsr305", "com.google.code.findbugs:jsr305:3.0.2")

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,7 @@ includeBuild("../checker-framework") {
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            version("checkerFramework", "3.21.5-SNAPSHOT")
+            version("checkerFramework", "3.21.5-jspecify-SNAPSHOT")
 
             library("checkerFramework-checker", "org.checkerframework", "checker").versionRef("checkerFramework")
             library("checkerFramework-checker-qual", "org.checkerframework", "checker-qual").versionRef("checkerFramework")

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,10 +12,6 @@ def initializeProject() {
     }
 }
 
-includeBuild("../checker-framework") {
-    initializeProject()
-}
-
 dependencyResolutionManagement {
     versionCatalogs {
         libs {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,13 +10,7 @@ exec {
     executable './initialize-project'
 }
 
-void includeBuildIfExists(String path) {
-    if (new File(path).isDirectory()) {
-        includeBuild(path)
-    }
-}
-
-includeBuildIfExists('../checker-framework')
+includeBuild('../checker-framework')
 
 dependencyResolutionManagement {
     versionCatalogs {

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ includeBuild("../checker-framework")
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            version("checkerFramework", "3.21.5-jspecify-SNAPSHOT")
+            version("checkerFramework", "3.21.5-SNAPSHOT")
 
             library("checkerFramework-checker", "org.checkerframework", "checker").versionRef("checkerFramework")
             library("checkerFramework-checker-qual", "org.checkerframework", "checker-qual").versionRef("checkerFramework")

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ exec {
     executable './initialize-project'
 }
 
-includeBuild('../checker-framework')
+includeBuild("../checker-framework")
 
 dependencyResolutionManagement {
     versionCatalogs {
@@ -27,7 +27,7 @@ dependencyResolutionManagement {
             library("guava", "com.google.guava:guava:31.1-jre")
             library("jspecify", "org.jspecify:jspecify:0.3.0")
             library("jspecify-conformanceTestFramework", "org.jspecify.conformance:conformance-test-framework:0.0.0-SNAPSHOT")
-            library("jspecify-conformanceTests", "org.jspecify.conformance:conformance-tests:0.1.0-SNAPSHOT")
+            library("jspecify-conformanceTests", "org.jspecify.conformance:conformance-tests:0.0.0-SNAPSHOT")
             library("jsr305", "com.google.code.findbugs:jsr305:3.0.2")
             library("junit", "junit:junit:4.12")
             library("truth", "com.google.truth:truth:1.1.3")

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,6 @@ void includeBuildIfExists(String path) {
     }
 }
 
-includeBuildIfExists('../jspecify')
 includeBuildIfExists('../checker-framework')
 
 dependencyResolutionManagement {

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,7 +35,7 @@ dependencyResolutionManagement {
             library("guava", "com.google.guava:guava:31.1-jre")
             library("jspecify", "org.jspecify:jspecify:0.0.0-SNAPSHOT")
             library("jspecify-conformanceTestFramework", "org.jspecify.conformance:conformance-test-framework:0.0.0-SNAPSHOT")
-            library("jspecify-conformanceTests", "org.jspecify.conformance:conformance-tests:0.0.0-SNAPSHOT")
+            library("jspecify-conformanceTests", "org.jspecify.conformance:conformance-tests:0.1.0-SNAPSHOT")
             library("jsr305", "com.google.code.findbugs:jsr305:3.0.2")
             library("junit", "junit:junit:4.12")
             library("truth", "com.google.truth:truth:1.1.3")

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,6 +39,7 @@ dependencyResolutionManagement {
             library("guava", "com.google.guava:guava:31.1-jre")
             library("jspecify", "org.jspecify:jspecify:0.0.0-SNAPSHOT")
             library("jspecify-conformanceTestFramework", "org.jspecify.conformance:conformance-test-framework:0.0.0-SNAPSHOT")
+            library("jspecify-conformanceTests", "org.jspecify.conformance:conformance-tests:0.0.0-SNAPSHOT")
             library("jsr305", "com.google.code.findbugs:jsr305:3.0.2")
             library("junit", "junit:junit:4.12")
             library("truth", "com.google.truth:truth:1.1.3")

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,10 +16,6 @@ includeBuild("../jspecify") {
     initializeProject()
 }
 
-includeBuild("../jdk") {
-    initializeProject()
-}
-
 includeBuild("../checker-framework") {
     initializeProject()
 }


### PR DESCRIPTION
Use the published JSpecify artifacts instead of requiring a local clone of https://github.com/jspecify/jspecify. Allow the user to include a local clone with `--included-build path/to/jspecify`, and use those artifacts instead in that case.

Requires https://github.com/jspecify/jspecify/pull/446.

Part of #107.