### PR TITLE
Using `ajavaChecks` option isn't necessary

### DIFF
--- a/src/test/java/tests/ConformanceTest.java
+++ b/src/test/java/tests/ConformanceTest.java
@@ -93,7 +93,6 @@ public final class ConformanceTest {
           "-AcheckImpl",
           "-AsuppressWarnings=conditional",
           "-Astrict",
-          "-AajavaChecks",
           "-AshowTypes");
 
   private static final ImmutableList<Path> TEST_DEPS =


### PR DESCRIPTION
Let's see whether CI agrees.