### PR TITLE
Handle unexpected diagnostics that aren't in "detail message" format.

### DIFF
--- a/src/test/java/tests/ConformanceTest.java
+++ b/src/test/java/tests/ConformanceTest.java
@@ -228,7 +228,7 @@ public final class ConformanceTest {
 
     @Override
     public String toString() {
-      return String.format("(%s) %s", detailMessage.messageKey, detailMessage.message);
+      return String.format("(%s) %s", detailMessage.messageKey, detailMessage.readableMessage);
     }
 
     /**

--- a/src/test/java/tests/DetailMessage.java
+++ b/src/test/java/tests/DetailMessage.java
@@ -46,7 +46,7 @@ final class DetailMessage extends TestDiagnostic {
                   "\\((?<messageKey>[^)]+)\\)", "(?<messagePartCount>\\d+)", "(?<messageParts>.*)"),
           DOTALL);
 
-  static final Pattern OFFSETS_PATTERN =
+  private static final Pattern OFFSETS_PATTERN =
       Pattern.compile("(\\( (?<start>-?\\d+), (?<end>-?\\d+) \\))?");
 
   /** The path to the source file containing the diagnostic. */
@@ -89,23 +89,6 @@ final class DetailMessage extends TestDiagnostic {
     this.readableMessage = readableMessage;
   }
 
-  static Integer intOrNull(String input) {
-    return input == null ? null : parseInt(input);
-  }
-
-  private DetailMessage(
-      Path file, int lineNumber, DiagnosticKind diagnosticKind, String readableMessage) {
-    this(
-        file,
-        lineNumber,
-        diagnosticKind,
-        "<none>",
-        ImmutableList.of(),
-        null,
-        null,
-        readableMessage);
-  }
-
   /**
    * Returns an object parsed from a diagnostic message, or {@code null} if the message doesn't
    * match the expected format.
@@ -129,7 +112,9 @@ final class DetailMessage extends TestDiagnostic {
     String message = messageMatcher.group("message");
     Matcher detailsMatcher = DETAIL_MESSAGE_PATTERN.matcher(message);
     if (!detailsMatcher.matches()) {
-      return new DetailMessage(file, lineNumber, kind, message);
+      // Return a message with no key or parts.
+      return new DetailMessage(
+          file, lineNumber, kind, "<none>", ImmutableList.of(), null, null, message);
     }
 
     int messagePartCount = parseInt(detailsMatcher.group("messagePartCount"));
@@ -154,6 +139,10 @@ final class DetailMessage extends TestDiagnostic {
         intOrNull(offsetsMatcher.group("start")),
         intOrNull(offsetsMatcher.group("end")),
         readableMessage);
+  }
+
+  private static Integer intOrNull(String input) {
+    return input == null ? null : parseInt(input);
   }
 
   /** The last part of the {@link #file}. */

--- a/src/test/java/tests/DetailMessage.java
+++ b/src/test/java/tests/DetailMessage.java
@@ -70,25 +70,6 @@ final class DetailMessage extends TestDiagnostic {
   /** The user-visible message emitted for the diagnostic. */
   final String readableMessage;
 
-  private DetailMessage(
-      Path file,
-      int lineNumber,
-      DiagnosticKind diagnosticKind,
-      String messageKey,
-      ImmutableList<String> messageArguments,
-      Integer offsetStart,
-      Integer offsetEnd,
-      String readableMessage) {
-    super(file.toString(), lineNumber, diagnosticKind, readableMessage, false, true);
-    this.file = file;
-    this.lineNumber = lineNumber;
-    this.messageKey = messageKey;
-    this.messageArguments = messageArguments;
-    this.offsetStart = offsetStart;
-    this.offsetEnd = offsetEnd;
-    this.readableMessage = readableMessage;
-  }
-
   /**
    * Returns an object parsed from a diagnostic message, or {@code null} if the message doesn't
    * match the expected format.
@@ -143,6 +124,25 @@ final class DetailMessage extends TestDiagnostic {
 
   private static Integer intOrNull(String input) {
     return input == null ? null : parseInt(input);
+  }
+
+  private DetailMessage(
+      Path file,
+      int lineNumber,
+      DiagnosticKind diagnosticKind,
+      String messageKey,
+      ImmutableList<String> messageArguments,
+      Integer offsetStart,
+      Integer offsetEnd,
+      String readableMessage) {
+    super(file.toString(), lineNumber, diagnosticKind, readableMessage, false, true);
+    this.file = file;
+    this.lineNumber = lineNumber;
+    this.messageKey = messageKey;
+    this.messageArguments = messageArguments;
+    this.offsetStart = offsetStart;
+    this.offsetEnd = offsetEnd;
+    this.readableMessage = readableMessage;
   }
 
   /** The last part of the {@link #file}. */

--- a/src/test/java/tests/DetailMessage.java
+++ b/src/test/java/tests/DetailMessage.java
@@ -94,8 +94,7 @@ final class DetailMessage extends TestDiagnostic {
     Matcher detailsMatcher = DETAIL_MESSAGE_PATTERN.matcher(message);
     if (!detailsMatcher.matches()) {
       // Return a message with no key or parts.
-      return new DetailMessage(
-          file, lineNumber, kind, "<none>", ImmutableList.of(), null, null, message);
+      return new DetailMessage(file, lineNumber, kind, "", ImmutableList.of(), null, null, message);
     }
 
     int messagePartCount = parseInt(detailsMatcher.group("messagePartCount"));
@@ -148,6 +147,14 @@ final class DetailMessage extends TestDiagnostic {
   /** The last part of the {@link #file}. */
   String getFileName() {
     return file.getFileName().toString();
+  }
+
+  /**
+   * True if this was parsed from an actual {@code -Adetailedmsgtext} message; false if this was
+   * some other diagnostic.
+   */
+  boolean hasDetails() {
+    return !messageKey.equals("");
   }
 
   @Override

--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -106,7 +106,7 @@ abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
     for (ListIterator<TestDiagnostic> i = unexpected.listIterator(); i.hasNext(); ) {
       TestDiagnostic diagnostic = i.next();
       DetailMessage detailMessage = DetailMessage.parse(diagnostic.getMessage(), null);
-      if (detailMessage != null) {
+      if (detailMessage != null && detailMessage.hasDetails()) {
         // Replace diagnostics that can be parsed with DetailMessage diagnostics.
         i.set(detailMessage);
       } else if (diagnostic.getKind() != DiagnosticKind.Error) {


### PR DESCRIPTION
Otherwise they were getting swallowed and never emitted even in details mode.