### PR TITLE
Don't log a warning when `fixType` sees a type it doesn't understand.

### DIFF
--- a/src/test/java/tests/ConformanceTest.java
+++ b/src/test/java/tests/ConformanceTest.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -84,8 +83,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public final class ConformanceTest {
-  private static final Logger logger = Logger.getLogger(ConformanceTest.class.getCanonicalName());
-
   private static final ImmutableList<String> OPTIONS =
       ImmutableList.of(
           "-AassumePure",
@@ -243,7 +240,6 @@ public final class ConformanceTest {
     private static String fixType(String type) {
       Matcher matcher = TYPE.matcher(type);
       if (!matcher.matches()) {
-        logger.warning(String.format("type \"%s\" did not match /%s/", type, TYPE.pattern()));
         return type;
       }
       String args = matcher.group("args");


### PR DESCRIPTION
That's just noise.