### PR TITLE
Fix the root project version so the Nexus Publish plugin knows to publish snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,9 @@ plugins {
     id 'net.ltgt.errorprone' version '3.0.1'
 }
 
-// Nexus Publish plugin requires a group at the root project.
+// Nexus Publish plugin requires a group/version at the root project.
 group = 'org.jspecify.reference'
+version = '0.0.0-SNAPSHOT'
 
 repositories {
     mavenLocal()

--- a/demo
+++ b/demo
@@ -15,7 +15,7 @@ if [ ! -e "${jspecify}" ]; then
       -DoutputDirectory="$(dirname "${jspecify}")"
   fi
 fi
-jspecify_reference_checker="${dir}/build/libs/jspecify-reference-checker.jar"
+jspecify_reference_checker="${dir}/build/libs/jspecify-reference-checker-0.0.0-SNAPSHOT.jar"
 if [ ! -e "${jspecify_reference_checker}" ]; then
   echo "Assembling jspecify-reference-checker"
   ./gradlew assemble


### PR DESCRIPTION
It's weird that it requires this at the root only. This should fix the build.