### PR TITLE
Only handle messages with details

### DIFF
--- a/src/test/java/tests/ConformanceTest.java
+++ b/src/test/java/tests/ConformanceTest.java
@@ -147,6 +147,7 @@ public final class ConformanceTest {
     return result.getUnexpectedDiagnostics().stream()
         .map(d -> DetailMessage.parse(d.getMessage(), testDirectory))
         .filter(Objects::nonNull)
+        .filter(DetailMessage::hasDetails)
         .map(DetailMessageReportedFact::new)
         .collect(toImmutableSet());
   }


### PR DESCRIPTION
#130 fixed handling of unexpected messages.
However, only the [test suite filtered out such messages](https://github.com/jspecify/jspecify-reference-checker/pull/130/files#diff-d0ccedbf8ecabed5c350d62c5e7831452fb612309cba05da83f0c13d2f928eb0R109).
This makes the corresponding change to the conformance test suite.

Before this PR, the conformance tests in main-eisop failed unexpectedly, as the main-eisop branch was rebased with the changes from #130 and the failure wasn't noticed until #134.