### PR TITLE
Tolerate a missing `getFileName` method on `Path`.

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/Util.java
+++ b/src/main/java/com/google/jspecify/nullness/Util.java
@@ -174,7 +174,7 @@ final class Util {
         optionalTypeElement(e, "java.nio.file.DirectoryStream").map(TypeElement::asType);
 
     pathGetFileNameElement =
-        onlyExecutableWithName(optionalTypeElement(e, "java.nio.file.Path"), "getFileName");
+        optionalOnlyExecutableWithName(optionalTypeElement(e, "java.nio.file.Path"), "getFileName");
 
     mapKeySetElement = onlyExecutableWithName(javaUtilMapElement, "keySet");
     mapContainsKeyElement = onlyExecutableWithName(javaUtilMapElement, "containsKey");


### PR DESCRIPTION
Soon `Path` will exist in J2KT but without `getFileName` (or any other
methods).

(That's happening to support `Truth.assertThat(Path)`, which is coming
as part of https://github.com/google/truth/issues/746.)

(reviewed and tested inside Google as cl/603379683)
