### PR TITLE
Try to fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-- package-ecosystem: gradle
+- package-ecosystem: "gradle"
   directory: "/"
   schedule:
-    interval: daily
+    interval: "daily"
 
 - package-ecosystem: "github-actions"
   directory: "/"


### PR DESCRIPTION
Spotless isn't being updated from [6.14](https://github.com/jspecify/jspecify-reference-checker/blob/17cd137c8a0fd8723d892be3a4ff2ffac551be46/build.gradle#L9) to the current 6.25 and several other versions are also out of date.
Maybe adding quotes helps.