### PR TITLE
Use standard error format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
         run: ./gradlew build conformanceTests demoTest --include-build ../jspecify
         env:
           SHALLOW: 1
-      - name: Check out jspecify/samples-google-prototype
+      - name: Check out jspecify/samples-google-prototype-eisop
         if: always()
         run: |
-          git fetch --depth=1 origin samples-google-prototype
-          git checkout samples-google-prototype
+          git fetch --depth=1 origin samples-google-prototype-eisop
+          git checkout samples-google-prototype-eisop
         working-directory: jspecify
       - name: Run Samples Tests
         if: always()

--- a/tests/ConformanceTest-report.txt
+++ b/tests/ConformanceTest-report.txt
@@ -1,4 +1,4 @@
-# 5 pass; 14 fail; 19 total; 26.3% score
+# 46 pass; 68 fail; 114 total; 40.4% score
 FAIL: Basic.java:28:test:expression-type:Object?:nullable
 FAIL: Basic.java:28:test:sink-type:Object!:return
 PASS: Basic.java:28:test:cannot-convert:Object? to Object!
@@ -18,3 +18,98 @@ FAIL: Irrelevant.java:49:test:irrelevant-annotation:NullUnmarked
 FAIL: Irrelevant.java: no unexpected facts
 PASS: UsesDep.java:24:test:cannot-convert:null? to Dep*
 PASS: UsesDep.java: no unexpected facts
+PASS: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:Nullable on simple type parameter on method:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:NonNull on simple type parameter on method:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:Nullable on bounded type parameter on method:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:NonNull on bounded type parameter on method:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:NonNull on annotated-bounded type parameter on method:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:Nullable on annotated-bounded type parameter on method:test:irrelevant-annotation:Nullable
+PASS: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:Nullable on simple type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:NonNull on simple type parameter on class:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:Nullable on bounded type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:NonNull on bounded type parameter on class:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:NonNull on annotated-bounded type parameter on class:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java:Nullable on annotated-bounded type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedTypeParameters.java: no unexpected facts
+PASS: irrelevantannotations/notnullmarked/AnnotatedWildcards.java:Nullable on unbounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedWildcards.java:NonNull on unbounded wildcard:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/AnnotatedWildcards.java:Nullable on bounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedWildcards.java:NonNull on bounded wildcard:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/notnullmarked/AnnotatedWildcards.java:NonNull on annotated-bounded wildcard:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/AnnotatedWildcards.java:Nullable on annotated-bounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/AnnotatedWildcards.java: no unexpected facts
+PASS: irrelevantannotations/notnullmarked/Other.java:Nullable local variable object:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull local variable object:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/Other.java:Nullable local variable array:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull local variable array:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/Other.java:Nullable exception parameter:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull exception parameter:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/notnullmarked/Other.java:Nullable try-with-resources:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull try-with-resources:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/notnullmarked/Other.java:Nullable exception type:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull exception type:test:irrelevant-annotation:NonNulll
+FAIL: irrelevantannotations/notnullmarked/Other.java: no unexpected facts
+PASS: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:Nullable on simple type parameter on method:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:NonNull on simple type parameter on method:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:Nullable on bounded type parameter on method:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:NonNull on bounded type parameter on method:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:NonNull on annotated-bounded type parameter on method:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:Nullable on annotated-bounded type parameter on method:test:irrelevant-annotation:Nullable
+PASS: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:Nullable on simple type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:NonNull on simple type parameter on class:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:Nullable on bounded type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:NonNull on bounded type parameter on class:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:NonNull on annotated-bounded type parameter on class:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java:Nullable on annotated-bounded type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedTypeParameters.java: no unexpected facts
+PASS: irrelevantannotations/nullmarked/AnnotatedWildcards.java:Nullable on unbounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedWildcards.java:NonNull on unbounded wildcard:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/AnnotatedWildcards.java:Nullable on bounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedWildcards.java:NonNull on bounded wildcard:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullmarked/AnnotatedWildcards.java:NonNull on annotated-bounded wildcard:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/AnnotatedWildcards.java:Nullable on annotated-bounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/AnnotatedWildcards.java: no unexpected facts
+PASS: irrelevantannotations/nullmarked/Other.java:Nullable local variable object:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/Other.java:NonNull local variable object:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/Other.java:Nullable local variable array:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/Other.java:NonNull local variable array:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/Other.java:Nullable exception parameter:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/Other.java:NonNull exception parameter:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullmarked/Other.java:Nullable try-with-resources:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/Other.java:NonNull try-with-resources:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullmarked/Other.java:Nullable exception type:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullmarked/Other.java:NonNull exception type:test:irrelevant-annotation:NonNulll
+FAIL: irrelevantannotations/nullmarked/Other.java: no unexpected facts
+PASS: irrelevantannotations/nullmarked/package-info.java: no unexpected facts
+PASS: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:Nullable on simple type parameter on method:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:NonNull on simple type parameter on method:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:Nullable on bounded type parameter on method:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:NonNull on bounded type parameter on method:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:NonNull on annotated-bounded type parameter on method:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:Nullable on annotated-bounded type parameter on method:test:irrelevant-annotation:Nullable
+PASS: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:Nullable on simple type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:NonNull on simple type parameter on class:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:Nullable on bounded type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:NonNull on bounded type parameter on class:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:NonNull on annotated-bounded type parameter on class:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java:Nullable on annotated-bounded type parameter on class:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedTypeParameters.java: no unexpected facts
+PASS: irrelevantannotations/nullunmarked/AnnotatedWildcards.java:Nullable on unbounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedWildcards.java:NonNull on unbounded wildcard:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/AnnotatedWildcards.java:Nullable on bounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedWildcards.java:NonNull on bounded wildcard:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullunmarked/AnnotatedWildcards.java:NonNull on annotated-bounded wildcard:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/AnnotatedWildcards.java:Nullable on annotated-bounded wildcard:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/AnnotatedWildcards.java: no unexpected facts
+PASS: irrelevantannotations/nullunmarked/Other.java:Nullable local variable object:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull local variable object:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/Other.java:Nullable local variable array:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull local variable array:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/Other.java:Nullable exception parameter:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull exception parameter:test:irrelevant-annotation:NonNull
+PASS: irrelevantannotations/nullunmarked/Other.java:Nullable try-with-resources:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull try-with-resources:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullunmarked/Other.java:Nullable exception type:test:irrelevant-annotation:Nullable
+FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull exception type:test:irrelevant-annotation:NonNulll
+FAIL: irrelevantannotations/nullunmarked/Other.java: no unexpected facts
+PASS: irrelevantannotations/nullunmarked/package-info.java: no unexpected facts

--- a/tests/minimal/Demo.java
+++ b/tests/minimal/Demo.java
@@ -18,7 +18,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 class Demo {
   Object mismatch(@Nullable Object o) {
-    // jspecify_nullness_mismatch
+    // :: error: jspecify_nullness_mismatch
     return o;
   }
 }


### PR DESCRIPTION
In https://github.com/eisop/checker-framework/pull/693 I removed some hacky workaround, not realizing that it is still used here.
As we're not planning to write many such tests, I think it's okay to just use the standard error format here.

Ideally, we would have a mechanism to allow type systems to more easily adapt the expected error lines themselves. 
However, at the moment there is a bunch of static methods that make extension hard.