### PR TITLE
Map `type.invalid.super.wildcard` as an expected error

### DIFF
--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -207,6 +207,7 @@ abstract class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
       case "jspecify_conflicting_annotations":
         switch (unexpected.messageKey) {
           case "type.invalid.conflicting.annos":
+          case "type.invalid.super.wildcard":
             return true;
           default:
             return false;


### PR DESCRIPTION
To handle the expected error added in:
https://github.com/jspecify/jspecify/pull/485