### PR TITLE
Ensure override compatibility with type variables

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -667,7 +667,10 @@ final class NullSpecAnnotatedTypeFactory
         // Work around wonkyness of CF override checks.
         AnnotatedTypeVariable subTV = (AnnotatedTypeVariable) subtype;
         if (isCapturedTypeVariable(subTV.getUnderlyingType())) {
-          subTV = (AnnotatedTypeVariable) subTV.getUpperBound();
+          AnnotatedTypeMirror subTVBnd = subTV.getUpperBound();
+          if (subTVBnd instanceof AnnotatedTypeVariable) {
+            subTV = (AnnotatedTypeVariable) subTVBnd;
+          }
         }
         AnnotatedTypeVariable superTV = (AnnotatedTypeVariable) supertype;
         if (areCorrespondingTypeVariables(elements, subTV, superTV)) {

--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -664,7 +664,11 @@ final class NullSpecAnnotatedTypeFactory
         return true;
       }
       if (subtype.getKind() == TYPEVAR && supertype.getKind() == TYPEVAR) {
+        // Work around wonkyness of CF override checks.
         AnnotatedTypeVariable subTV = (AnnotatedTypeVariable) subtype;
+        if (isCapturedTypeVariable(subTV.getUnderlyingType())) {
+          subTV = (AnnotatedTypeVariable) subTV.getUpperBound();
+        }
         AnnotatedTypeVariable superTV = (AnnotatedTypeVariable) supertype;
         if (areCorrespondingTypeVariables(elements, subTV, superTV)) {
           return isSubtype(subTV.getUpperBound(), superTV.getUpperBound())

--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -31,6 +31,7 @@ import static javax.lang.model.type.TypeKind.ARRAY;
 import static javax.lang.model.type.TypeKind.DECLARED;
 import static javax.lang.model.type.TypeKind.TYPEVAR;
 import static javax.lang.model.type.TypeKind.WILDCARD;
+import static org.checkerframework.framework.util.AnnotatedTypes.areCorrespondingTypeVariables;
 import static org.checkerframework.framework.util.AnnotatedTypes.asSuper;
 import static org.checkerframework.javacutil.AnnotationUtils.areSame;
 import static org.checkerframework.javacutil.TreePathUtil.enclosingClass;
@@ -639,6 +640,14 @@ final class NullSpecAnnotatedTypeFactory
           && !supertype.hasAnnotation(minusNull)
           && isNullnessSubtype(subtype, ((AnnotatedTypeVariable) supertype).getLowerBound())) {
         return true;
+      }
+      if (subtype.getKind() == TYPEVAR && supertype.getKind() == TYPEVAR) {
+        AnnotatedTypeVariable subTV = (AnnotatedTypeVariable) subtype;
+        AnnotatedTypeVariable superTV = (AnnotatedTypeVariable) supertype;
+        if (areCorrespondingTypeVariables(elements, subTV, superTV)) {
+          return isSubtype(subTV.getUpperBound(), superTV.getUpperBound())
+              && isSubtype(superTV.getLowerBound(), subTV.getLowerBound());
+        }
       }
       return isNullInclusiveUnderEveryParameterization(supertype)
           || isNullExclusiveUnderEveryParameterization(subtype)

--- a/tests/ConformanceTestOnSamples-report.txt
+++ b/tests/ConformanceTestOnSamples-report.txt
@@ -1,4 +1,4 @@
-# 73 pass; 500 fail; 573 total; 12.7% score
+# 74 pass; 499 fail; 573 total; 12.9% score
 FAIL: AnnotatedInnerOfNonParameterized.java: no unexpected facts
 FAIL: AnnotatedInnerOfParameterized.java: no unexpected facts
 FAIL: AnnotatedReceiver.java: no unexpected facts
@@ -313,7 +313,7 @@ PASS: OutOfBoundsTypeVariable.java: no unexpected facts
 FAIL: OverrideParameters.java:48:jspecify_nullness_mismatch
 FAIL: OverrideParameters.java:68:jspecify_nullness_mismatch
 FAIL: OverrideParameters.java: no unexpected facts
-FAIL: OverrideParametersThatAreTypeVariables.java: no unexpected facts
+PASS: OverrideParametersThatAreTypeVariables.java: no unexpected facts
 FAIL: OverrideReturns.java:57:jspecify_nullness_mismatch
 FAIL: OverrideReturns.java: no unexpected facts
 PASS: ParameterizedWithTypeVariableArgumentToSelf.java: no unexpected facts

--- a/tests/regression/Issue164.java
+++ b/tests/regression/Issue164.java
@@ -1,0 +1,33 @@
+// Copyright 2024 The JSpecify Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test case for Issue 164:
+// https://github.com/jspecify/jspecify-reference-checker/issues/164
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+interface Issue164SuperWildcardParent {
+  <T extends @Nullable Object> void x(Issue164Foo<? super T> foo);
+}
+
+@NullMarked
+interface Issue164SuperWildcardOverride extends Issue164SuperWildcardParent {
+  @Override
+  <T extends @Nullable Object> void x(Issue164Foo<? super T> foo);
+}
+
+@NullMarked
+interface Issue164Foo<T extends @Nullable Object> {}

--- a/tests/regression/Issue164More.java
+++ b/tests/regression/Issue164More.java
@@ -19,15 +19,14 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-interface Issue164SuperWildcardParent {
-  <T extends @Nullable Object> void x(Issue164Foo<? super T> foo);
-}
+class Issue164More {
+  interface Super<T extends @Nullable Object> {
+    <U extends T> void foo(Lib<? extends U> lib);
+  }
 
-@NullMarked
-interface Issue164SuperWildcardOverride extends Issue164SuperWildcardParent {
-  @Override
-  <U extends @Nullable Object> void x(Issue164Foo<? super U> foo);
-}
+  interface Sub<V extends @Nullable Object> extends Super<V> {
+    <W extends V> void foo(Lib<? extends W> lib);
+  }
 
-@NullMarked
-interface Issue164Foo<V extends @Nullable Object> {}
+  interface Lib<X extends @Nullable Object> {}
+}


### PR DESCRIPTION
I want to look whether there is a better fix for this, maybe by moving this check into the override checker.
Instead, maybe something is wrong with the logic in the `return` statement that follows this change.
Let me know if this looks familiar.

Fixes #164.