### PR TITLE
Disable checking of contracts.

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -592,16 +592,16 @@ final class NullSpecAnnotatedTypeFactory
       case TYPEVAR:
         return singletonList(((AnnotatedTypeVariable) type).getUpperBound());
 
-      /*
-       * We used to have a case here for WILDCARD. It shouldn't be necessary now that we've merged
-       * the CF implementation capture conversion. That said, we shouldn't need wildcard handling
-       * in isNullnessSubtype, either, and yet we do.
-       *
-       * So we could consider restoring wildcard handling here, too. But for now, we've left it
-       * out, since its implementation required some digging into javac internal types and calling
-       * getAnnotatedType (always a little scary, as discussed in
-       * NullSpecTreeAnnotator.visitMethodInvocation and elsewhere).
-       */
+        /*
+         * We used to have a case here for WILDCARD. It shouldn't be necessary now that we've merged
+         * the CF implementation capture conversion. That said, we shouldn't need wildcard handling
+         * in isNullnessSubtype, either, and yet we do.
+         *
+         * So we could consider restoring wildcard handling here, too. But for now, we've left it
+         * out, since its implementation required some digging into javac internal types and calling
+         * getAnnotatedType (always a little scary, as discussed in
+         * NullSpecTreeAnnotator.visitMethodInvocation and elsewhere).
+         */
 
       default:
         return emptyList();

--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -110,6 +110,10 @@ import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.type.typeannotator.TypeAnnotator;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeVisitor;
 import org.checkerframework.framework.util.AnnotationFormatter;
+import org.checkerframework.framework.util.Contract.ConditionalPostcondition;
+import org.checkerframework.framework.util.Contract.Postcondition;
+import org.checkerframework.framework.util.Contract.Precondition;
+import org.checkerframework.framework.util.ContractsFromMethod;
 import org.checkerframework.framework.util.DefaultAnnotationFormatter;
 import org.checkerframework.framework.util.DefaultQualifierKindHierarchy;
 import org.checkerframework.framework.util.QualifierKindHierarchy;
@@ -588,16 +592,16 @@ final class NullSpecAnnotatedTypeFactory
       case TYPEVAR:
         return singletonList(((AnnotatedTypeVariable) type).getUpperBound());
 
-        /*
-         * We used to have a case here for WILDCARD. It shouldn't be necessary now that we've merged
-         * the CF implementation capture conversion. That said, we shouldn't need wildcard handling
-         * in isNullnessSubtype, either, and yet we do.
-         *
-         * So we could consider restoring wildcard handling here, too. But for now, we've left it
-         * out, since its implementation required some digging into javac internal types and calling
-         * getAnnotatedType (always a little scary, as discussed in
-         * NullSpecTreeAnnotator.visitMethodInvocation and elsewhere).
-         */
+      /*
+       * We used to have a case here for WILDCARD. It shouldn't be necessary now that we've merged
+       * the CF implementation capture conversion. That said, we shouldn't need wildcard handling
+       * in isNullnessSubtype, either, and yet we do.
+       *
+       * So we could consider restoring wildcard handling here, too. But for now, we've left it
+       * out, since its implementation required some digging into javac internal types and calling
+       * getAnnotatedType (always a little scary, as discussed in
+       * NullSpecTreeAnnotator.visitMethodInvocation and elsewhere).
+       */
 
       default:
         return emptyList();
@@ -917,6 +921,28 @@ final class NullSpecAnnotatedTypeFactory
        */
       return false;
     }
+  }
+
+  // Disable checking of contracts.
+  @Override
+  protected ContractsFromMethod createContractsFromMethod() {
+    return new ContractsFromMethod(this) {
+      @Override
+      public Set<ConditionalPostcondition> getConditionalPostconditions(
+          ExecutableElement methodElement) {
+        return emptySet();
+      }
+
+      @Override
+      public Set<Precondition> getPreconditions(ExecutableElement executableElement) {
+        return emptySet();
+      }
+
+      @Override
+      public Set<Postcondition> getPostconditions(ExecutableElement executableElement) {
+        return emptySet();
+      }
+    };
   }
 
   @Override


### PR DESCRIPTION
We've historically accomplished this with `-AsuppressWarnings`, but this
CL's solution may be more general. Also, it avoids running some code
entirely, which saves us from having to keep that code updated for the
very new JDKs that we run with. (It might also help performance if we're
lucky, and maybe it moves us a step closer to not needing JavaParser
(though that may be on the way out, anyway).)
