### PR TITLE
Recommend JDK 17, not 18.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These instructions might require workarounds or fail outright. Please file an is
 
 ### Prework
 
-Ideally set `JAVA_HOME` to a JDK 11 or JDK 18 installation.
+Ideally set `JAVA_HOME` to a JDK 11 or JDK 17 installation.
 
 Make sure you have Apache Maven installed and in your PATH, or the Gradle build will fail:
 


### PR DESCRIPTION
Maybe this was a typo?

My build with 18 failed mysteriously:

```
$ JAVA_HOME=$HOME/jdk-18.0.1.1 ./gradlew clean assemble
...
> Task :checker-framework:framework:compileJava
/tmp/tmp.PDgUgNUXFY/checker-framework/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java:82: warning: [serial] non-transient instance field of a serializable class declared with a non-serializable type
    TreePath path;
             ^
error: warnings found and -Werror specified
/tmp/tmp.PDgUgNUXFY/checker-framework/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java:1108: warning: [serial] non-transient instance field of a serializable class declared with an array having a non-serializable base component type Object
    public final Object[] args;
                          ^
1 error
2 warnings
```

A similar build with 21 fails faster and with more actionable information:

```
$ JAVA_HOME=$HOME/jdk-21.0.2 ./gradlew assemble
...
A problem occurred evaluating project ':checker-framework'.
> Build the Checker Framework with JDK 8, 11, or 17. Found version 21
```

As hoped, `JAVA_HOME=$HOME/jdk-17.0.2 ./gradlew assemble` seems to be going fine.