### PR TITLE
Automatically download 1.0.0 of JSpecify instead of 0.3.0.

### DIFF
--- a/demo
+++ b/demo
@@ -6,11 +6,11 @@
 dir=$(dirname $0)
 jspecify="${dir}/../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"
 if [ ! -e "${jspecify}" ]; then
-  version=0.3.0
+  version=1.0.0
   jspecify="${dir}/build/jspecify-${version}.jar"
   if [ ! -e "${jspecify}" ]; then
     echo "Downloading $(basename "${jspecify}") from Maven central"
-    mvn -q org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy \
+    mvn -q org.apache.maven.plugins:maven-dependency-plugin:3.7.1:copy \
       -Dartifact="org.jspecify:jspecify:${version}" \
       -DoutputDirectory="$(dirname "${jspecify}")"
   fi


### PR DESCRIPTION
Also, bump `maven-dependency-plugin` while in the neighborhood.
