### PR TITLE
Fix capture conversion in lenient mode.

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -532,6 +532,14 @@ final class NullSpecAnnotatedTypeFactory
   }
 
   @Override
+  public AnnotatedTypeMirror applyCaptureConversion(
+      AnnotatedTypeMirror type, TypeMirror typeMirror) {
+    return this == withLeastConvenientWorld
+        ? super.applyCaptureConversion(type, typeMirror)
+        : withLeastConvenientWorld.applyCaptureConversion(type, typeMirror);
+  }
+
+  @Override
   protected TypeHierarchy createTypeHierarchy() {
     return new NullSpecTypeHierarchy(
         checker,

--- a/tests/regression/Issue197.java
+++ b/tests/regression/Issue197.java
@@ -1,0 +1,33 @@
+// Copyright 2024 The JSpecify Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test case for Issue 197:
+// https://github.com/jspecify/jspecify-reference-checker/issues/197
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+class Issue197<E> {
+  interface Function<A, B> {}
+
+  interface Super<E> {
+    void i(Function<? super E, ? extends E> p);
+  }
+
+  @NullMarked
+  interface Sub<E extends @Nullable Object> extends Super<E> {
+    @Override
+    void i(Function<? super E, ? extends E> p);
+  }
+}


### PR DESCRIPTION
...by always performing capture conversion in _strict_ mode, where there
is a better-defined hierarchy (non-null < unspecified < nullable, with
no "but also unspecified < non-null if you want).

Fixes https://github.com/jspecify/jspecify-reference-checker/issues/193
