### PR TITLE
Treat `@PolyNull` like `@Nullable`.

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -1963,7 +1963,7 @@ final class NullSpecAnnotatedTypeFactory
                 "com.google.gerrit.common.Nullable",
                 "com.google.protobuf.Internal.ProtoMethodAcceptsNullParameter",
                 "com.google.protobuf.Internal.ProtoMethodMayReturnNull",
-                // TODO(cpovirk): Treat this like a @PolyNull instead:
+                // TODO(cpovirk): Give this proper @PolyNull behavior:
                 "com.google.protobuf.Internal.ProtoPassThroughNullness",
                 "com.mongodb.lang.Nullable",
                 "com.sun.istack.Nullable",
@@ -1995,6 +1995,8 @@ final class NullSpecAnnotatedTypeFactory
                 "org.checkerframework.checker.nullness.compatqual.NullableType",
                 "org.checkerframework.checker.nullness.qual.MonotonicNonNull",
                 "org.checkerframework.checker.nullness.qual.Nullable",
+                // TODO(cpovirk): Give this proper @PolyNull behavior:
+                "org.checkerframework.checker.nullness.qual.PolyNull",
                 "org.codehaus.commons.nullanalysis.Nullable",
                 "org.eclipse.jdt.annotation.Nullable",
                 "org.eclipse.jgit.annotations.Nullable",


### PR DESCRIPTION
This seems like something that we would have discussed previously, but I can't find any evidence of that.

- Maybe the hope was that we'd soon implement _full_ support from scratch based on forthcoming JSpecify rules for `@PolyNull`?
- Maybe the hope was that we'd be able to [make `@PolyNull` "imply" `@Nullable`](https://github.com/jspecify/jspecify/issues/307#issuecomment-1294416722) soon?
- Maybe the plan was to tell Checker Framework users to write [`@Nullable @PolyNull`](https://github.com/jspecify/jspecify/issues/35)?
- Maybe we once had a principle of recognizing only annotations that were "universally" recognized (or at least recognized by Kotlin), while `@PolyNull` is _not_? But if so, we moved away from that long ago.

For now, it seems useful to at least recognize it. I could see us backtracking if we were to fall back to a policy of (at least optionally) recognizing _only_ JSpecify annotations or _only_ "universally" recognized annotations. But if we do so, that will involve a larger change than just reverting back this PR.

(My immediate motivation is that J2CL is looking at `@PolyNull` support (@kevinoconnor7 FYI), and we've been trying to keep our lists of annotations in sync with theirs.)

Hmm, and you know, only now that I'm writing this am I realizing that making `@PolyNull` imply `@Nullable` would not actually be sound, at least for the class definition of `@PolyNull`. I'll leave a note on https://github.com/jspecify/jspecify/issues/79 and maybe in a doc or two that we have going about `@Implies`, assuming that I don't convince myself that I'm wrong by then. If I'm right, then it would actually make conceptual sense to _not_ merge this PR, either....