### PR TITLE
Update versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
     id 'com.diffplug.spotless' version '6.25.0'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
-    id 'net.ltgt.errorprone' version '3.0.1'
+    id 'net.ltgt.errorprone' version '4.1.0'
     // To show task list as a tree, run: ./gradlew <taskname> taskTree
     id 'com.dorongold.task-tree' version '4.0.0'
 }
@@ -121,6 +121,7 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs.add("-Xlint:-fallthrough")
 
     options.errorprone.disable("BadImport")
+    options.errorprone.disable("VoidUsed")
 
     options.compilerArgs.addAll(
             [

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ dependencyResolutionManagement {
             library("checkerFramework-framework", "io.github.eisop", "framework").versionRef("checkerFramework")
             library("checkerFramework-framework-test", "io.github.eisop", "framework-test").versionRef("checkerFramework")
             library("checkerFramework-javacutil", "io.github.eisop", "javacutil").versionRef("checkerFramework")
-            library("errorProne-core", "com.google.errorprone:error_prone_core:2.18.0")
+            library("errorProne-core", "com.google.errorprone:error_prone_core:2.36.0")
             library("errorProne-javac", "com.google.errorprone:javac:9+181-r4173-1")
             library("guava", "com.google.guava:guava:31.1-jre")
 

--- a/usage-demo/build.gradle
+++ b/usage-demo/build.gradle
@@ -3,13 +3,13 @@
 plugins {
     id 'java'
     id 'com.diffplug.spotless' version '6.25.0'
-    id 'net.ltgt.errorprone' version '3.1.0'
-    id 'org.checkerframework' version '0.6.42' apply false
+    id 'net.ltgt.errorprone' version '4.1.0'
+    id 'org.checkerframework' version '0.6.48' apply false
 }
 
 ext {
     versions = [
-        eisopVersion: '3.42.0-eisop4',
+        eisopVersion: '3.42.0-eisop5',
         jspecifyVersion: '1.0.0',
         jspecifyReferenceCheckerVersion: '0.0.0-SNAPSHOT'
     ]
@@ -22,7 +22,7 @@ repositories {
 
 // Project dependencies, e.g. error prone.
 dependencies {
-    errorprone 'com.google.errorprone:error_prone_core:2.23.0'
+    errorprone 'com.google.errorprone:error_prone_core:2.36.0'
 }
 
 // Dependency on JSpecify annotations.
@@ -37,6 +37,7 @@ apply plugin: 'org.checkerframework'
 dependencies {
     compileOnly "io.github.eisop:checker-qual:${versions.eisopVersion}"
     testCompileOnly "io.github.eisop:checker-qual:${versions.eisopVersion}"
+    checkerFramework "io.github.eisop:checker-qual:${versions.eisopVersion}"
     checkerFramework "io.github.eisop:checker:${versions.eisopVersion}"
 
     compileOnly "org.jspecify.reference:checker:${versions.jspecifyReferenceCheckerVersion}"


### PR DESCRIPTION
#217 updates the depandabot configuration, but that probably doesn't update the `main-eisop` branch.
It also doesn't seem to update the `main` branch, as the build file there also has many out-of-date versions.