### PR TITLE
Use new Sonatype Central URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,18 +18,18 @@ version = '0.0.0-SNAPSHOT'
 repositories {
     mavenLocal()
     maven {
-        // Nexus snapshot repository
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+        name = 'ossrh-staging-api'
+        url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
     }
     mavenCentral()
 }
 
 nexusPublishing {
     repositories {
+        // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
         sonatype {
-            // For users registered in Sonatype after 24 Feb 2021
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
-            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
A downstream test of the JSpecify Conformance Tests is failing with:

````
Build file '/home/runner/work/checker-framework/jspecify-conformance/build.gradle' line: 96

* What went wrong:
A problem occurred evaluating root project 'jspecify-conformance'.
> Could not resolve all files for configuration ':jSpecifyConformanceTests'.
   > Could not resolve org.jspecify.conformance:conformance-tests:0.0.0-SNAPSHOT.
     Required by:
         root project :
      > Could not resolve org.jspecify.conformance:conformance-tests:0.0.0-SNAPSHOT.
         > Could not get resource 'https://s01.oss.sonatype.org/content/repositories/snapshots/org/jspecify/conformance/conformance-tests/0.0.0-SNAPSHOT/conformance-tests-0.0.0-20250602.125545-66.pom'.
            > Could not GET 'https://s01.oss.sonatype.org/content/repositories/snapshots/org/jspecify/conformance/conformance-tests/0.0.0-SNAPSHOT/conformance-tests-0.0.0-20250602.125545-66.pom'. Received status code 504 from server: Gateway Time-out
````

Links:
- https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#authentication
- https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central
- https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuring-the-repository
- https://central.sonatype.org/publish/publish-portal-snapshots/

You will need to create new tokens, see the first link.

I haven't tried these changes... I'm not sure how to test the changes first.