### PR TITLE
Avoid a NPE on implicit lambda parameter types

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/NullSpecVisitor.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecVisitor.java
@@ -467,7 +467,10 @@ final class NullSpecVisitor extends BaseTypeVisitor<NullSpecAnnotatedTypeFactory
     if (util.hasSuppressWarningsNullness(annotations)) {
       return null;
     }
-
+    // implicit lambda parameter types
+    if (tree.getType() == null) {
+      return null;
+    }
     if (isPrimitiveOrArrayOfPrimitive(tree.getType())) {
       checkNoNullnessAnnotations(tree, annotations, "primitive.annotated");
     } else if (tree.getType().getKind() == MEMBER_SELECT) {


### PR DESCRIPTION
After https://bugs.openjdk.org/browse/JDK-8268850, `VariableTree#getType` will return `null` for implicit lambda parameter types.